### PR TITLE
Do not release `StringIO` instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [1.1.0] - 2024-11-28
+
+- Do not release `StringIO` instances. [(#7)](https://github.com/viralpraxis/rspec-description_consistency/pull/7)
+
 ## [1.0.4] - 2024-08-13
 
 - Fix `ActiveModel` attribute misdetection [(#4)](https://github.com/viralpraxis/rspec-description_consistency/pull/4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rspec-description_consistency (1.0.4)
+    rspec-description_consistency (1.1.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/rspec/description_consistency/resource_manager.rb
+++ b/lib/rspec/description_consistency/resource_manager.rb
@@ -9,6 +9,7 @@ module RSpec
         return unless io
         return if [$stdout, $stderr].include?(io)
         return if io.closed?
+        return if io.is_a?(StringIO) || (defined?(RSpec::Core::OutputWrapper) && io.is_a?(RSpec::Core::OutputWrapper))
 
         io.close
       end

--- a/lib/rspec/description_consistency/version.rb
+++ b/lib/rspec/description_consistency/version.rb
@@ -2,6 +2,6 @@
 
 module Rspec
   module DescriptionConsistency
-    VERSION = '1.0.4'
+    VERSION = '1.1.0'
   end
 end


### PR DESCRIPTION
Some RSpec plugins provide `StringIO` instances as the output stream; they should the close it by themselves.